### PR TITLE
Stability improvement and minor fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
-Launch4j Demo Application
+# Launch4j Demo Application
 
 Example application how to use Launch4j Maven plugin
 
+## Running
+
+1. Ensure, that you have JDK version `>=1.8` and Maven version `>= 3.6` installed.
+2. Please run the Maven `package` phase:
+
+```bash
+mvn clean package
+```
+
+3. Created executable should be available under `target/` directory (the filename depends on POM configuration, i.e. `app.exe`).

--- a/pom.xml
+++ b/pom.xml
@@ -25,62 +25,60 @@
     </dependencies>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>com.akathist.maven.plugins.launch4j</groupId>
-                    <artifactId>launch4j-maven-plugin</artifactId>
-                    <version>2.2.0</version>
-                    <executions>
-                        <execution>
-                            <id>l4j-clui</id>
-                            <phase>package</phase>
-                            <goals>
-                                <goal>launch4j</goal>
-                            </goals>
-                            <configuration>
-                                <headerType>gui</headerType>
-                                <jar>${project.build.directory}/${project.artifactId}-${project.version}.jar</jar>
-                                <outfile>${project.build.directory}/app.exe</outfile>
-                                <downloadUrl>http://java.com/download</downloadUrl>
-                                <classPath>
-                                    <mainClass>software.orphan.launch4j.App</mainClass>
-                                    <preCp>anything</preCp>
-                                </classPath>
-                                <jre>
-                                    <path>%JAVA_HOME%;%PATH%</path>
-                                    <minVersion>1.8</minVersion>
-                                    <bundledJreAsFallback>true</bundledJreAsFallback>
-                                    <jdkPreference>preferJre</jdkPreference>
-                                    <requiresJdk>true</requiresJdk>
-                                    <bundledJre64Bit>true</bundledJre64Bit>
-                                    <runtimeBits>32</runtimeBits>
-                                    <opts>
-                                        <opt>-Dname=Lukasz</opt>
-                                    </opts>
-                                </jre>
-                                <messages>
-                                    <bundledJreErr>Test bundledJreErr</bundledJreErr>
-                                </messages>
-                                <versionInfo>
-                                    <fileVersion>1.0.0.0</fileVersion>
-                                    <txtFileVersion>${project.version}</txtFileVersion>
-                                    <fileDescription>Launch4j Demo App</fileDescription>
-                                    <copyright>Lukasz Lenart</copyright>
-                                    <productVersion>1.0.0.0</productVersion>
-                                    <txtProductVersion>1.0.0.0</txtProductVersion>
-                                    <productName>App</productName>
-                                    <companyName>Lukasz Lenart</companyName>
-                                    <internalName>app</internalName>
-                                    <originalFilename>app.exe</originalFilename>
-                                    <trademarks>Luk ™</trademarks>
-                                </versionInfo>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-            </plugins>
-        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>com.akathist.maven.plugins.launch4j</groupId>
+                <artifactId>launch4j-maven-plugin</artifactId>
+                <version>2.2.0</version>
+                <executions>
+                    <execution>
+                        <id>l4j-clui</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>launch4j</goal>
+                        </goals>
+                        <configuration>
+                            <headerType>gui</headerType>
+                            <jar>${project.build.directory}/${project.artifactId}-${project.version}.jar</jar>
+                            <outfile>${project.build.directory}/app.exe</outfile>
+                            <downloadUrl>http://java.com/download</downloadUrl>
+                            <classPath>
+                                <mainClass>software.orphan.launch4j.App</mainClass>
+                                <preCp>anything</preCp>
+                            </classPath>
+                            <jre>
+                                <path>%JAVA_HOME%;%PATH%</path>
+                                <minVersion>1.8</minVersion>
+                                <bundledJreAsFallback>true</bundledJreAsFallback>
+                                <jdkPreference>preferJre</jdkPreference>
+                                <requiresJdk>true</requiresJdk>
+                                <bundledJre64Bit>true</bundledJre64Bit>
+                                <runtimeBits>32</runtimeBits>
+                                <opts>
+                                    <opt>-Dname=Lukasz</opt>
+                                </opts>
+                            </jre>
+                            <messages>
+                                <bundledJreErr>Test bundledJreErr</bundledJreErr>
+                            </messages>
+                            <versionInfo>
+                                <fileVersion>1.0.0.0</fileVersion>
+                                <txtFileVersion>${project.version}</txtFileVersion>
+                                <fileDescription>Launch4j Demo App</fileDescription>
+                                <copyright>Lukasz Lenart</copyright>
+                                <productVersion>1.0.0.0</productVersion>
+                                <txtProductVersion>1.0.0.0</txtProductVersion>
+                                <productName>App</productName>
+                                <companyName>Lukasz Lenart</companyName>
+                                <internalName>app</internalName>
+                                <originalFilename>app.exe</originalFilename>
+                                <trademarks>Luk ™</trademarks>
+                            </versionInfo>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
     <profiles>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
                 <version>2.2.0</version>
                 <executions>
                     <execution>
-                        <id>l4j-clui</id>
+                        <id>l4j-gui</id>
                         <phase>package</phase>
                         <goals>
                             <goal>launch4j</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>software.orphan.launch4j</groupId>
     <artifactId>launch4j-demo</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>launch4j-demo</name>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
                 <plugin>
                     <groupId>com.akathist.maven.plugins.launch4j</groupId>
                     <artifactId>launch4j-maven-plugin</artifactId>
-                    <version>2.2.0-SNAPSHOT</version>
+                    <version>2.2.0</version>
                     <executions>
                         <execution>
                             <id>l4j-clui</id>
@@ -129,10 +129,10 @@
             <layout>default</layout>
             <name>OSS Sonatype Snapshots</name>
             <releases>
-                <enabled>false</enabled>
+                <enabled>true</enabled>
             </releases>
             <snapshots>
-                <enabled>true</enabled>
+                <enabled>false</enabled>
             </snapshots>
         </pluginRepository>
     </pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
             <plugin>
                 <groupId>com.akathist.maven.plugins.launch4j</groupId>
                 <artifactId>launch4j-maven-plugin</artifactId>
-                <version>2.2.0</version>
+                <version>2.2.0-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <id>l4j-gui</id>
@@ -127,10 +127,10 @@
             <layout>default</layout>
             <name>OSS Sonatype Snapshots</name>
             <releases>
-                <enabled>true</enabled>
+                <enabled>false</enabled>
             </releases>
             <snapshots>
-                <enabled>false</enabled>
+                <enabled>true</enabled>
             </snapshots>
         </pluginRepository>
     </pluginRepositories>


### PR DESCRIPTION
Changes applied:
- instructions about how to run it added to the README
-  `<pluginManagement>` removed from the POM.xml file, because it makes the Launch4j maven plugin be invoked for any project extending this parent (and not invoked by this project itself)
- minor typos in XML configuration fixed